### PR TITLE
Remove example dependency

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,7 +29,7 @@ catkin_package(
   INCLUDE_DIRS include
   LIBRARIES myahrs_driver
   CATKIN_DEPENDS roscpp std_msgs sensor_msgs tf
-  DEPENDS system_lib
+  DEPENDS
 )
 
 ################################################################################


### PR DESCRIPTION
Our CI fails because it cannot find system_lib.

It doesn't seem to be a 'real' dependency in the package (never called in the code). 
Probably came in with an example:
https://answers.ros.org/question/288967/build-package-with-system_lib-not-found/